### PR TITLE
Fix gauge labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Managed Prometheus Exporter for Machine Objects
 
-As a stopgap until [openshift/machine-api-operator](https://github.com/openshift/machine-api-operator) exports metrics, this will export a metrics.
+Purpose is a stopgap until [openshift/machine-api-operator](https://github.com/openshift/machine-api-operator) exports metrics we can alert on.  The one goal of this repo is to have a gauge on which SRE can create an alert to trigger when a node has not been created for some period of time.
+
 
 ## Exported Metrics
 
-* `machine_api_status` is a Gauge that has four labels and a possibility one or two values. `0` for when there is no corresponding `Node`, `1` for when there is such a `Node`.
+* `machine_api_status` is a Gauge that has two labels and a possibility one or two values. `0` for when there is no corresponding `Node`, `1` for when there is such a `Node`.
   * `machine_name` - Name of the `Machine` custom resource (CR)
-  * `node_name` - `Node` name that corresponds to the `Machine` object, if the node exists (`""` otherwise)
-  * `instance_state` - State reported by the `Machine` object of the cloud instance
-  * `instance_id`- ID of the corresponding cloud instance, if one exists (`""` otherwise)
+  * `namespace` - Namespace in which `Machine` custom resource is defined

--- a/hack/00-osd-managed-prometheus-exporter-machine-api.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-machine-api.selectorsyncset.yaml.tmpl
@@ -39,7 +39,7 @@ objects:
         template:
           metadata:
             annotations:
-              managed.openshift.io/exporter_source_code_hash: 3c3c7a2cb887b31b205c0032eaf655b03dba92e4d40a677c3d5e77440029056a
+              managed.openshift.io/exporter_source_code_hash: 72e6dfeaabb891ca7875db6e184388b38141bc7ffb8e1944ed729174d738951e
             labels:
               name: sre-machine-api-status-exporter
             name: sre-machine-api-status-exporter
@@ -124,58 +124,26 @@ objects:
           os\nimport time\n\nfrom prometheus_client import start_http_server, Gauge\nfrom
           kubernetes import client, config\nfrom kubernetes.client import ApiClient,
           Configuration\nfrom openshift.dynamic import DynamicClient\n\nMACHINE_STATUS
-          = Gauge('machine_api_status',\"Status of Machine CRs\", labelnames=['machine_name','node_name','instance_state','instance_id'])\nMACHINE_INFO
-          = Gauge('machine_api_info',\"Information about Machine CRs\", labelnames=['machine_name',
-          'region', 'availability_zone', 'instance_type', 'machine_creation_time',
-          'image_id'])\n\n# A list (implemented as a Set) of all active Machines\nACTIVE_MACHINES
-          = Set([])\n\ndef get_machines(dynamic_client,namespace):\n    \"\"\"Gets
-          all of the Machine objects from the cluster from the specified namespace.\n
+          = Gauge('machine_api_status',\"1 if machine has an associated node\", labelnames=['machine_name','namespace'])\n\n#
+          A list (implemented as a Set) of all active Machines\nACTIVE_MACHINES =
+          Set([])\n\ndef get_machines(dynamic_client,namespace):\n    \"\"\"Gets all
+          of the Machine objects from the cluster from the specified namespace.\n
           \   \"\"\"\n    machines = dynamic_client.resources.get(kind='Machine')\n
           \   return machines.get(namespace=namespace).items\n\ndef collect(dynamic_client,
           namespace):\n    \"\"\"\n    Collect the current data from the AWS API.\n
           \   \"\"\"\n\n    # List of volumes that we've actually had data back for
           the API\n    seen_machines = Set([])\n    machines = get_machines(dynamic_client,
           namespace)\n    for machine in machines:\n        seen_machines.add(machine['metadata']['name'])\n
-          \       ACTIVE_MACHINES.add(machine['metadata']['name'])\n\n        node_name
-          = \"\"\n        instanceid = \"\"\n        instance_state = \"not-created\"\n
-          \       value = 1\n        if 'nodeRef' in machine['status'].keys():\n            node_name
-          = machine['status']['nodeRef']['name']\n        else:\n            value
-          = 0\n\n        if 'providerStatus' in machine['status'].keys():\n            if
-          'instanceId' in machine['status']['providerStatus'].keys():\n                instanceid
-          = machine['status']['providerStatus']['instanceId']\n            else:\n
-          \               value = 0\n            if 'instanceState' in machine['status']['providerStatus'].keys():\n
-          \               instance_state = machine['status']['providerStatus']['instanceState']\n\n
-          \       MACHINE_STATUS.labels(\n            machine_name   = machine['metadata']['name'],\n
-          \           node_name      = node_name,\n            instance_state = instance_state,\n
-          \           instance_id    = instanceid\n        ).set(value)\n\n        MACHINE_INFO.labels(\n
-          \           machine_name          = machine['metadata']['name'],\n            region
-          \               = machine['spec']['providerSpec']['value']['placement']['region'],\n
-          \           availability_zone     = machine['spec']['providerSpec']['value']['placement']['availabilityZone'],\n
-          \           instance_type         = machine['spec']['providerSpec']['value']['instanceType'],\n
-          \           machine_creation_time = machine['metadata']['creationTimestamp'],\n
-          \           image_id              = machine['spec']['providerSpec']['value']['ami']['id']\n
-          \       ).set(value)\n\n    logging.debug(\"Have %d ACTIVE_MACHINES, seen
-          %d machines, total machines from list_metrics %d\",len(ACTIVE_MACHINES),len(seen_machines),len(machines))\n
+          \       ACTIVE_MACHINES.add(machine['metadata']['name'])\n\n        value
+          = 1\n        if not 'status' in machine.keys() or not 'nodeRef' in machine['status'].keys():\n
+          \           value = 0\n\n        MACHINE_STATUS.labels(\n            machine_name
+          = machine['metadata']['name'],\n            namespace = namespace\n        ).set(value)\n\n
+          \   logging.debug(\"Have %d ACTIVE_MACHINES, seen %d machines, total machines
+          from list_metrics %d\",len(ACTIVE_MACHINES),len(seen_machines),len(machines))\n
           \   for inactive_machine in ACTIVE_MACHINES - seen_machines:\n        logging.info(\"Removing
-          machine_id='%s' from Prometheus \",inactive_machine)\n        node_name
-          = \"\"\n        instanceid = \"\"\n        instance_state = \"not-created\"\n
-          \       if 'nodeRef' in machine['status'].keys():\n            node_name
-          = machine['status']['nodeRef']['name']\n        if 'providerStatus' in machine['status'].keys():\n
-          \           if 'instanceId' in machine['status']['providerStatus'].keys():\n
-          \               instanceid = machine['status']['providerStatus']['instanceId']\n
-          \           else:\n                value = 0\n            if 'instanceState'
-          in machine['status']['providerStatus'].keys():\n                instance_state
-          = machine['status']['providerStatus']['instanceState']\n\n        MACHINE_INFO.remove(\n
-          \           machine_name          = machine['metadata']['name'],\n            region
-          \               = machine['spec']['providerSpec']['value']['placement']['region'],\n
-          \           availability_zone     = machine['spec']['providerSpec']['value']['placement']['availabilityZone'],\n
-          \           instance_type         = machine['spec']['providerSpec']['value']['instanceType'],\n
-          \           machine_creation_time = machine['metadata']['creationTimestamp'],\n
-          \           image_id              = machine['spec']['providerSpec']['value']['ami']['id']\n
-          \       )\n        MACHINE_STATUS.remove(\n            machine_name   =
-          inactive_machine['metadata']['name'],\n            node_name      = node_name,\n
-          \           instance_state = instance_state,\n            instance_id    =
-          instanceid\n        )\n        ACTIVE_MACHINES.remove(inactive_machine)\n\nif
+          machine_api_status{machine_name='%s'} from Prometheus \",inactive_machine)\n\n
+          \       MACHINE_STATUS.remove(\n            machine_name = inactive_machine,\n
+          \           namespace = namespace\n        )\n        \n        ACTIVE_MACHINES.remove(inactive_machine)\n\nif
           __name__ == \"__main__\":\n    logging.basicConfig(level=logging.INFO, format='%(asctime)s
           %(levelname)s:%(name)s:%(message)s')\n\n    namespace = \"openshift-machine-api\"\n
           \   if \"MACHINE_NAMESPACE\" in os.environ:\n        namespace = os.getenv(\"MACHINE_NAMESPACE\")\n\n

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -11,8 +11,7 @@ from kubernetes import client, config
 from kubernetes.client import ApiClient, Configuration
 from openshift.dynamic import DynamicClient
 
-MACHINE_STATUS = Gauge('machine_api_status',"Status of Machine CRs", labelnames=['machine_name','node_name','instance_state','instance_id'])
-MACHINE_INFO = Gauge('machine_api_info',"Information about Machine CRs", labelnames=['machine_name', 'region', 'availability_zone', 'instance_type', 'machine_creation_time', 'image_id'])
+MACHINE_STATUS = Gauge('machine_api_status',"1 if machine has an associated node", labelnames=['machine_name','namespace'])
 
 # A list (implemented as a Set) of all active Machines
 ACTIVE_MACHINES = Set([])
@@ -35,69 +34,24 @@ def collect(dynamic_client, namespace):
         seen_machines.add(machine['metadata']['name'])
         ACTIVE_MACHINES.add(machine['metadata']['name'])
 
-        node_name = ""
-        instanceid = ""
-        instance_state = "not-created"
         value = 1
-        if 'nodeRef' in machine['status'].keys():
-            node_name = machine['status']['nodeRef']['name']
-        else:
+        if not 'status' in machine.keys() or not 'nodeRef' in machine['status'].keys():
             value = 0
 
-        if 'providerStatus' in machine['status'].keys():
-            if 'instanceId' in machine['status']['providerStatus'].keys():
-                instanceid = machine['status']['providerStatus']['instanceId']
-            else:
-                value = 0
-            if 'instanceState' in machine['status']['providerStatus'].keys():
-                instance_state = machine['status']['providerStatus']['instanceState']
-
         MACHINE_STATUS.labels(
-            machine_name   = machine['metadata']['name'],
-            node_name      = node_name,
-            instance_state = instance_state,
-            instance_id    = instanceid
-        ).set(value)
-
-        MACHINE_INFO.labels(
-            machine_name          = machine['metadata']['name'],
-            region                = machine['spec']['providerSpec']['value']['placement']['region'],
-            availability_zone     = machine['spec']['providerSpec']['value']['placement']['availabilityZone'],
-            instance_type         = machine['spec']['providerSpec']['value']['instanceType'],
-            machine_creation_time = machine['metadata']['creationTimestamp'],
-            image_id              = machine['spec']['providerSpec']['value']['ami']['id']
+            machine_name = machine['metadata']['name'],
+            namespace = namespace
         ).set(value)
 
     logging.debug("Have %d ACTIVE_MACHINES, seen %d machines, total machines from list_metrics %d",len(ACTIVE_MACHINES),len(seen_machines),len(machines))
     for inactive_machine in ACTIVE_MACHINES - seen_machines:
-        logging.info("Removing machine_id='%s' from Prometheus ",inactive_machine)
-        node_name = ""
-        instanceid = ""
-        instance_state = "not-created"
-        if 'nodeRef' in machine['status'].keys():
-            node_name = machine['status']['nodeRef']['name']
-        if 'providerStatus' in machine['status'].keys():
-            if 'instanceId' in machine['status']['providerStatus'].keys():
-                instanceid = machine['status']['providerStatus']['instanceId']
-            else:
-                value = 0
-            if 'instanceState' in machine['status']['providerStatus'].keys():
-                instance_state = machine['status']['providerStatus']['instanceState']
+        logging.info("Removing machine_api_status{machine_name='%s'} from Prometheus ",inactive_machine)
 
-        MACHINE_INFO.remove(
-            machine_name          = machine['metadata']['name'],
-            region                = machine['spec']['providerSpec']['value']['placement']['region'],
-            availability_zone     = machine['spec']['providerSpec']['value']['placement']['availabilityZone'],
-            instance_type         = machine['spec']['providerSpec']['value']['instanceType'],
-            machine_creation_time = machine['metadata']['creationTimestamp'],
-            image_id              = machine['spec']['providerSpec']['value']['ami']['id']
-        )
         MACHINE_STATUS.remove(
-            machine_name   = inactive_machine['metadata']['name'],
-            node_name      = node_name,
-            instance_state = instance_state,
-            instance_id    = instanceid
+            machine_name = inactive_machine,
+            namespace = namespace
         )
+        
         ACTIVE_MACHINES.remove(inactive_machine)
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://jira.coreos.com/browse/SREP-1852

When labels "change" a new gauge is created.  Old gauge is never removed.  Alerts trigger that shouldn't.

NOTE reverting the machine_api_status stuff.  We can sync on why later @lisa but quick summary is we cannot change labels for a gauge with the client we're using without keeping state in order to clean things up.