### PR TITLE
Switch from nodeSelector to node affinity

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-machine-api.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-machine-api.selectorsyncset.yaml.tmpl
@@ -44,6 +44,14 @@ objects:
               name: sre-machine-api-status-exporter
             name: sre-machine-api-status-exporter
           spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
             containers:
             - command:
               - /bin/sh
@@ -77,8 +85,6 @@ objects:
                 readOnly: true
               workingDir: /monitor
             dnsPolicy: ClusterFirst
-            nodeSelector:
-              node-role.kubernetes.io/infra: ''
             restartPolicy: Always
             serviceAccountName: sre-machine-api-status-exporter
             tolerations:

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -50,8 +50,14 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: $SERVICEACCOUNT_NAME
-      nodeSelector:
-        node-role.kubernetes.io/infra: ''
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+            weight: 1
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/infra


### PR DESCRIPTION
* this ensures managed-prometheus-exporter-ebs-iops-reporter is also
deployed if no infra nodes exist